### PR TITLE
Fix dependency installation in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,7 @@ jobs:
   tests:
       runs-on: ubuntu-latest
       strategy:
+        fail-fast: false
         matrix:
           python-version: [ "3.8", "3.9", "3.10", "3.11" ]
 
@@ -19,10 +20,15 @@ jobs:
           uses: actions/setup-python@v4
           with:
             python-version: ${{ matrix.python-version }}
-        - name: Install dependencies
+        - name: Install Linux dependencies
+          run: |
+            sudo apt-get install libsdl2-2.0 libwxgtk3.0-gtk3-dev
+        - name: Install Python dependencies
           run: |
             python -m pip install --upgrade pip
-            pip install -r requirements.txt
+            pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04 -r requirements.txt
         - name: Test with pytest
+          env:
+            PYTHONPATH: /opt/trelby
           run: |
-            pytest
+            /opt/trelby/bin/pytest


### PR DESCRIPTION
This change fixes installation errors during GitHub Actions test runs via the following:

- Add the remote directory hosted by the wxPython project to the pip install command so that pip finds the pre-built wheels instead of installing from source. While installing from source in CI should be doable, it would be significantly more expensive and slower than this wheel approach. This method is documented at the bottom of the wxPython wiki page at https://wiki.wxpython.org/How%20to%20install%20wxPython.

- Add Linux shared library dependencies. These are required by the wheel installation of wxPython at runtime.

- Disable fail-fast in the test matrix strategy to prevent a test failure on one version of Python from cancelling the remaining test jobs.

Effects of this change:

- GitHub Actions runs for Python 3.8 and 3.9 pass as expected.

- Tests fail under Python 3.10 due to a runtime error. This is likely due to pip deprecation warnings emitted for 3.8 and 3.9 turning into real errors in the 3.10 environment. Changes to the installation config are required to fix this; these changes should be made in a followup commit and are beyond the scope of the CI change made here.

- Tests fail under Python 3.11 because wxPython does not currently provide wheels for 3.11. Installing from source could be an option here, but due to the additional work required (as mentioned above), it may make sense to wait for 3.11 wheels to become available for the purposes of the test suite.